### PR TITLE
Group /store/docs/ methods seperately from /store/docs/:uid methods.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -139,9 +139,20 @@ Retrieves all docs for the authenticated user.
 }
 ```
 
-### `/store/docs/:uid` : `GET`
+### `/store/docs` : `POST`
 
-Retrieves a specific doc for the authenticated user.
+Creates a new doc for the authenticated user.
+
+#### Request
+
+```json
+{
+	"file": {
+		"title": "string",
+		"body": "Object[]"
+	}
+}
+```
 
 #### Response
 
@@ -161,20 +172,9 @@ Retrieves a specific doc for the authenticated user.
 }
 ```
 
-### `/store/docs` : `POST`
+### `/store/docs/:uid` : `GET`
 
-Creates a new doc for the authenticated user.
-
-#### Request
-
-```json
-{
-	"file": {
-		"title": "string",
-		"body": "Object[]"
-	}
-}
-```
+Retrieves a specific doc for the authenticated user.
 
 #### Response
 


### PR DESCRIPTION
When you look at the "Files changed" diffs this looks extremely confusing, but all I did was move the GET method for /store/docs/:uid next to the other /store/docs/:uid methods.