### PR TITLE
Payment details for /credit endpoint.

### DIFF
--- a/docs/api/internal.md
+++ b/docs/api/internal.md
@@ -390,7 +390,7 @@ _Body:_
 
 #### 200
 
-The text was generated.
+The text was generated. `cost` gives the number of credits used in the API call.
 
 _Body:_
 
@@ -405,6 +405,7 @@ _Body:_
 			}
 		]
 	}
+	"cost": "float"
 }
 ```
 
@@ -444,7 +445,7 @@ There was no authenticated user to return credits for.
 
 ## `/credits` : `POST`
 
-Opens a Stripe payment window to be completed by the user. If successful, adds the given number of credits to the authenticated user's account.
+Opens a Stripe payment window to be completed by the user. If successful, adds the given number of credits to the authenticated user's account. One credit is 1¢ in USD.
 
 ### Request
 


### PR DESCRIPTION
Nearly finished - the only additional detail is how to handle the case where the user does not have enough credits for the maximum length of response. 

I was thinking of using a `scale` parameter like this in the request:
```
{
            "prompt": {
                "name": "Test Prompt",
                "messages": [
                    {
                        "role": "user",
                        "content": "Please add more detail to the following text. Do not add information for the sake of it, simply add more relevant information that will enhance the value of the information. The text input is the following: 'The sky is blue.'"
                    }
                ]
            },
            "scale": true
        }
```

* If `scale` is in the request, the LLM will scale down its response as needed. 
* If `scale` is not in the request, and there are not enough credits for the maximum length response, an error will be given.

This is what the relevant backend code currently looks like:

```python
is_scaling_output = True if 'scale' in data else False

if self.prompt_cost(prompt) > user.credits:
    print(self.prompt_cost(prompt))
    return Response({"error": "The cost of your prompt exceeds your remaining credits."}, status=status.HTTP_402_PAYMENT_REQUIRED)

# If the maximum cost of the LLM is too high, and the user has 
# not opted to scale down the response output, end the payment.
if self.max_cost(prompt) > user.credits and not is_scaling_output:
    return Response({"error": "Insufficient credits for the response. Please add credits or select 'Scale Down Output'."}, status=status.HTTP_402_PAYMENT_REQUIRED)
```

Please let me know if you'd like me to adjust these endpoints!